### PR TITLE
Add CircleCI to run tests on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2.1
+jobs:
+  build:
+    working_directory: ~/family-friday
+    docker:
+      - image: circleci/node:10.16.3
+    steps:
+      - checkout
+      - run:
+          name: update-npm
+          command: 'sudo npm install -g npm@latest'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
+      - run:
+          name: install-npm-wee
+          command: npm install
+      - save_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
+          paths:
+            - ./node_modules
+      - run:
+          name: test
+          command: npm test
+      - store_artifacts:
+          path: test-results.xml
+          prefix: tests
+      - store_test_results:
+          path: test-results.xml

--- a/src/components/__snapshots__/FamilyFriday.test.js.snap
+++ b/src/components/__snapshots__/FamilyFriday.test.js.snap
@@ -12,6 +12,7 @@ Object {
           Family Friday Lunch Lottery
         </h1>
         Loading Employees...
+        <div />
         <div
           class="newHire"
         >
@@ -45,6 +46,7 @@ Object {
         Family Friday Lunch Lottery
       </h1>
       Loading Employees...
+      <div />
       <div
         class="newHire"
       >


### PR DESCRIPTION
I used [CircleCI's example node config file](https://circleci.com/docs/2.0/language-javascript/) as the basis for the configuration.

Also, I needed to add empty `<div>`s in a couple of snapshots to get them to match the test output. I'm not sure if this is a legitimate diff or if I have different versions of modules than the versions used when the snapshots were generated.

Since the base branch is in the upstream repo (`lynnpark/family-friday`), [CircleCI needs to be configured for that repo](https://circleci.com/docs/2.0/oss/#build-pull-requests-from-forked-repositories) in order for the build status to show up in this PR. Regardless, the [build status for this PR is green](https://circleci.com/gh/tcollier/family-friday/3).